### PR TITLE
fix: stop SVG element from taking space

### DIFF
--- a/src/components/Icons.astro
+++ b/src/components/Icons.astro
@@ -1,4 +1,4 @@
-<svg>
+<svg style="width: 0; height: 0; position: absolute;">
     <defs>
         <path
             id="rss"


### PR DESCRIPTION
## Changes
- needed to add special styling to fully hide the SVG defs from the page DOM

## Tickets
- #6 